### PR TITLE
Import Directive direct from docutils.

### DIFF
--- a/sphinxcontrib/youtube.py
+++ b/sphinxcontrib/youtube.py
@@ -5,8 +5,7 @@ from __future__ import division
 
 import re
 from docutils import nodes
-from docutils.parsers.rst import directives
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import directives, Directive
 
 CONTROL_HEIGHT = 30
 


### PR DESCRIPTION
`Directive` is no longer in `sphinx.util.compat`.