### PR TITLE
Youtube is only relevant for html. Ignore all other output formats.

### DIFF
--- a/sphinxcontrib/youtube.py
+++ b/sphinxcontrib/youtube.py
@@ -99,6 +99,21 @@ class YouTube(Directive):
         height = get_size(self.options, "height")
         return [youtube(id=self.arguments[0], aspect=aspect, width=width, height=height)]
 
+
+def unsupported_visit_youtube(self, node):
+    self.builder.warn('youtube: unsupported output format (node skipped)')
+    raise nodes.SkipNode
+
+
+_NODE_VISITORS = {
+    'html': (visit_youtube_node, depart_youtube_node),
+    'latex': (unsupported_visit_youtube, None),
+    'man': (unsupported_visit_youtube, None),
+    'texinfo': (unsupported_visit_youtube, None),
+    'text': (unsupported_visit_youtube, None)
+}
+
+
 def setup(app):
-    app.add_node(youtube, html=(visit_youtube_node, depart_youtube_node))
+    app.add_node(youtube, **_NODE_VISITORS)
     app.add_directive("youtube", YouTube)


### PR DESCRIPTION
This PR makes the youtube extension return SkipNode for all other output formats than html, since youtube doesn't make sense for them. Without it, we get the following error:

```
Exception occurred:
  File "/opt/cantemo/python/lib/python2.7/site-packages/sphinx/writers/text.py", line 1196, in unknown_visit
    raise NotImplementedError('Unknown node: ' + node.__class__.__name__)
NotImplementedError: Unknown node: youtube
The full traceback has been saved in /tmp/sphinx-err-vUIECt.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

The code is copied from https://github.com/sphinx-contrib/plantuml/blob/master/sphinxcontrib/plantuml.py
