### PR TITLE
Output hyperlink in LaTeX instead of crashing

### DIFF
--- a/sphinxcontrib/youtube.py
+++ b/sphinxcontrib/youtube.py
@@ -75,6 +75,10 @@ def visit_youtube_node(self, node):
 def depart_youtube_node(self, node):
     pass
 
+def visit_youtube_node_latex(self,node):
+    self.body.append(r'\begin{quote}\begin{center}\fbox{\url{https://www.youtu.be/%s}}\end{center}\end{quote}'%node['id'])
+
+
 class YouTube(Directive):
     has_content = True
     required_arguments = 1
@@ -100,5 +104,8 @@ class YouTube(Directive):
         return [youtube(id=self.arguments[0], aspect=aspect, width=width, height=height)]
 
 def setup(app):
-    app.add_node(youtube, html=(visit_youtube_node, depart_youtube_node))
+    app.add_node(youtube,
+        html=(visit_youtube_node, depart_youtube_node),
+        latex=(visit_youtube_node_latex, depart_youtube_node)
+    )
     app.add_directive("youtube", YouTube)


### PR DESCRIPTION
Centered, framed, clickable:

![image](https://user-images.githubusercontent.com/1029876/40383664-b4942052-5e01-11e8-8022-3e905555abe9.png)
