### PR TITLE
Vimeo support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# Visual Studio Code settings
+.vscode
+
 # Rope project settings
 .ropeproject
 

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,16 @@ parameters "aspect", "width", and "height" may optionally be provided::
     ..  youtube:: oHg5SJYRHA0
         :height: 200px
 
-A simple link to the video, enclosed in a box, will be inserted in LaTeX output.
+In LaTeX output, the followinging code will be emitted for YouTube::
 
-..  -*- mode: rst; fill-column: 72 -*-
+    \sphinxcontribyoutube{https://youtu.be/}{oHg5SJYRHA0}
+
+The user may customise the rendering of the URL by defining this command in 
+the premble. If they do not, then the default definition is used::
+
+    \newcommand{\sphinxcontribvimeo}[2]{\begin{quote}\begin{center}\fbox{\url{#1#2}}\end{center}\end{quote}}
+
+This prints a simple link to the video, enclosed in a box. LaTeX support for
+Vimeo is similar, except that the macro is named `\sphinxcontribvimeo`.
+
+..  -*- mode: rst; fill-column: 79 -*-

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,18 @@
 sphinxcontrib.youtube
 =====================
 
-This module defines a directive, `youtube`.  It takes a single, required
-argument, a YouTube video ID::
+This module provides support for including YouTube and Vimeo videos
+in Sphinx rst documents.
+
+This module defines directives, `youtube` and `vimeo` which insert videos
+from the respective platforms. They take a single, required argument, a 
+YouTube video ID::
 
     ..  youtube:: oHg5SJYRHA0
+
+or a Vimeo video ID::
+
+    .. vimeo:: 486106801
 
 The referenced video will be embedded into HTML output.  By default, the
 embedded video will be sized for 720p content.  To control this, the

--- a/sphinxcontrib/youtube/__init__.py
+++ b/sphinxcontrib/youtube/__init__.py
@@ -1,0 +1,7 @@
+from  . import youtube, vimeo
+
+def setup(app):
+    app.add_node(youtube.youtube, **youtube._NODE_VISITORS)
+    app.add_directive("youtube", youtube.YouTube)
+    app.add_node(vimeo.vimeo, **vimeo._NODE_VISITORS)
+    app.add_directive("vimeo", vimeo.Vimeo)

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -84,8 +84,13 @@ def depart_video_node(self, node):
     pass
 
 
-def visit_video_node_latex(self, node, platform_url):
-    self.body.append(r'\begin{quote}\begin{center}\fbox{\url{%s%s}}\end{center}\end{quote}' % (platform_url, node['id']))
+def visit_video_node_latex(self, node, platform, platform_url):
+    macro = r"\sphinxcontrib%s" % platform
+    if macro not in self.elements["preamble"]:
+        self.elements["preamble"] += r"""
+        \newcommand{%s}[2]{\begin{quote}\begin{center}\fbox{\url{#1#2}}\end{center}\end{quote}}
+        """ % macro
+    self.body.append('%s{%s}{%s}\n' % (macro, platform_url, node['id']))
 
 
 class Video(Directive):

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -1,0 +1,14 @@
+import re
+
+
+def get_size(d, key):
+    if key not in d:
+        return None
+    m = re.match("(\d+)(|%|px)$", d[key])
+    if not m:
+        raise ValueError("invalid size %r" % d[key])
+    return int(m.group(1)), m.group(2) or "px"
+
+
+def css(d):
+    return "; ".join(sorted("%s: %s" % kv for kv in d.items()))

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -1,4 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import re
+from docutils import nodes
+from docutils.parsers.rst import directives, Directive
+
+CONTROL_HEIGHT = 30
 
 
 def get_size(d, key):
@@ -12,3 +19,101 @@ def get_size(d, key):
 
 def css(d):
     return "; ".join(sorted("%s: %s" % kv for kv in d.items()))
+
+
+class video(nodes.General, nodes.Element):
+    pass
+
+
+def visit_video_node(self, node, platform_url):
+    aspect = node["aspect"]
+    width = node["width"]
+    height = node["height"]
+
+    if aspect is None:
+        aspect = 16, 9
+
+    div_style = {}
+    if (height is None) and (width is not None) and (width[1] == "%"):
+        div_style = {
+            "padding-top": "%dpx" % CONTROL_HEIGHT,
+            "padding-bottom": "%f%%" % (width[0] * aspect[1] / aspect[0]),
+            "width": "%d%s" % width,
+            "position": "relative",
+        }
+        style = {
+            "position": "absolute",
+            "top": "0",
+            "left": "0",
+            "width": "100%",
+            "height": "100%",
+            "border": "0",
+        }
+        attrs = {
+            "src": f"{platform_url}{node['id']}",
+            "style": css(style),
+        }
+    else:
+        if width is None:
+            if height is None:
+                width = 560, "px"
+            else:
+                width = height[0] * aspect[0] / aspect[1], "px"
+        if height is None:
+            height = width[0] * aspect[1] / aspect[0], "px"
+        style = {
+            "width": "%d%s" % width,
+            "height": "%d%s" % (height[0] + CONTROL_HEIGHT, height[1]),
+            "border": "0",
+        }
+        attrs = {
+            "src":  f"{platform_url}{node['id']}",
+            "style": css(style),
+        }
+    attrs["allowfullscreen"] = "true"
+    div_attrs = {
+        "CLASS": "video_wrapper",
+        "style": css(div_style),
+    }
+    self.body.append(self.starttag(node, "div", **div_attrs))
+    self.body.append(self.starttag(node, "iframe", **attrs))
+    self.body.append("</iframe></div>")
+
+
+def depart_video_node(self, node):
+    pass
+
+
+def visit_video_node_latex(self, node, platform_url):
+    self.body.append(r'\begin{quote}\begin{center}\fbox{\url{%s%s}}\end{center}\end{quote}' % (platform_url, node['id']))
+
+
+class Video(Directive):
+    _node = None # Subclasses should replace with node class.
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+    option_spec = {
+        "width": directives.unchanged,
+        "height": directives.unchanged,
+        "aspect": directives.unchanged,
+    }
+
+    def run(self):
+        if "aspect" in self.options:
+            aspect = self.options.get("aspect")
+            m = re.match("(\d+):(\d+)", aspect)
+            if m is None:
+                raise ValueError("invalid aspect ratio %r" % aspect)
+            aspect = tuple(int(x) for x in m.groups())
+        else:
+            aspect = None
+        width = get_size(self.options, "width")
+        height = get_size(self.options, "height")
+        return [self._node(id=self.arguments[0], aspect=aspect, width=width, height=height)]
+
+
+def unsupported_visit_video(self, node, platform):
+    self.builder.warn(f'{platform}: unsupported output format (node skipped)')
+    raise nodes.SkipNode

--- a/sphinxcontrib/youtube/vimeo.py
+++ b/sphinxcontrib/youtube/vimeo.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import re
+from docutils import nodes
+from docutils.parsers.rst import directives, Directive
+from .utils import get_size, css
+from .youtube import depart_youtube_node
+
+CONTROL_HEIGHT = 30
+
+class vimeo(nodes.General, nodes.Element): pass
+
+def visit_vimeo_node(self, node):
+    aspect = node["aspect"]
+    width = node["width"]
+    height = node["height"]
+
+    if aspect is None:
+        aspect = 16, 9
+
+    div_style = {}
+    if (height is None) and (width is not None) and (width[1] == "%"):
+        div_style = {
+            "padding-top": "%dpx" % CONTROL_HEIGHT,
+            "padding-bottom": "%f%%" % (width[0] * aspect[1] / aspect[0]),
+            "width": "%d%s" % width,
+            "position": "relative",
+        }
+        style = {
+            "position": "absolute",
+            "top": "0",
+            "left": "0",
+            "width": "100%",
+            "height": "100%",
+            "border": "0",
+        }
+        attrs = {
+            "src": "https://player.vimeo.com/video/%s" % node["id"],
+            "style": css(style),
+        }
+    else:
+        if width is None:
+            if height is None:
+                width = 560, "px"
+            else:
+                width = height[0] * aspect[0] / aspect[1], "px"
+        if height is None:
+            height = width[0] * aspect[1] / aspect[0], "px"
+        style = {
+            "width": "%d%s" % width,
+            "height": "%d%s" % (height[0] + CONTROL_HEIGHT, height[1]),
+            "border": "0",
+        }
+        attrs = {
+            "src": "https://player.vimeo.com/video/%s" % node["id"],
+            "style": css(style),
+        }
+    attrs["allowfullscreen"] = "true"
+    div_attrs = {
+        "CLASS": "vimeo_wrapper",
+        "style": css(div_style),
+    }
+    self.body.append(self.starttag(node, "div", **div_attrs))
+    self.body.append(self.starttag(node, "iframe", **attrs))
+    self.body.append("</iframe></div>")
+
+def visit_vimeo_node_latex(self,node):
+    self.body.append(r'\begin{quote}\begin{center}\fbox{\url{https://player.vimeo.com/video/%s}}\end{center}\end{quote}'%node['id'])
+
+
+class Vimeo(Directive):
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+    option_spec = {
+        "width": directives.unchanged,
+        "height": directives.unchanged,
+        "aspect": directives.unchanged,
+    }
+
+    def run(self):
+        if "aspect" in self.options:
+            aspect = self.options.get("aspect")
+            m = re.match("(\d+):(\d+)", aspect)
+            if m is None:
+                raise ValueError("invalid aspect ratio %r" % aspect)
+            aspect = tuple(int(x) for x in m.groups())
+        else:
+            aspect = None
+        width = get_size(self.options, "width")
+        height = get_size(self.options, "height")
+        return [vimeo(id=self.arguments[0], aspect=aspect, width=width, height=height)]
+
+
+def unsupported_visit_vimeo(self, node):
+    self.builder.warn('vimeo: unsupported output format (node skipped)')
+    raise nodes.SkipNode
+
+
+_NODE_VISITORS = {
+    'html': (visit_vimeo_node, depart_youtube_node),
+    'latex': (visit_vimeo_node_latex, depart_youtube_node),
+    'man': (unsupported_visit_vimeo, None),
+    'texinfo': (unsupported_visit_vimeo, None),
+    'text': (unsupported_visit_vimeo, None)
+}
+
+
+def setup(app):
+    app.add_node(vimeo, **_NODE_VISITORS)
+    app.add_directive("vimeo", vimeo)

--- a/sphinxcontrib/youtube/vimeo.py
+++ b/sphinxcontrib/youtube/vimeo.py
@@ -1,113 +1,33 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-import re
-from docutils import nodes
-from docutils.parsers.rst import directives, Directive
-from .utils import get_size, css
-from .youtube import depart_youtube_node
-
-CONTROL_HEIGHT = 30
-
-class vimeo(nodes.General, nodes.Element): pass
-
-def visit_vimeo_node(self, node):
-    aspect = node["aspect"]
-    width = node["width"]
-    height = node["height"]
-
-    if aspect is None:
-        aspect = 16, 9
-
-    div_style = {}
-    if (height is None) and (width is not None) and (width[1] == "%"):
-        div_style = {
-            "padding-top": "%dpx" % CONTROL_HEIGHT,
-            "padding-bottom": "%f%%" % (width[0] * aspect[1] / aspect[0]),
-            "width": "%d%s" % width,
-            "position": "relative",
-        }
-        style = {
-            "position": "absolute",
-            "top": "0",
-            "left": "0",
-            "width": "100%",
-            "height": "100%",
-            "border": "0",
-        }
-        attrs = {
-            "src": "https://player.vimeo.com/video/%s" % node["id"],
-            "style": css(style),
-        }
-    else:
-        if width is None:
-            if height is None:
-                width = 560, "px"
-            else:
-                width = height[0] * aspect[0] / aspect[1], "px"
-        if height is None:
-            height = width[0] * aspect[1] / aspect[0], "px"
-        style = {
-            "width": "%d%s" % width,
-            "height": "%d%s" % (height[0] + CONTROL_HEIGHT, height[1]),
-            "border": "0",
-        }
-        attrs = {
-            "src": "https://player.vimeo.com/video/%s" % node["id"],
-            "style": css(style),
-        }
-    attrs["allowfullscreen"] = "true"
-    div_attrs = {
-        "CLASS": "vimeo_wrapper",
-        "style": css(div_style),
-    }
-    self.body.append(self.starttag(node, "div", **div_attrs))
-    self.body.append(self.starttag(node, "iframe", **attrs))
-    self.body.append("</iframe></div>")
-
-def visit_vimeo_node_latex(self,node):
-    self.body.append(r'\begin{quote}\begin{center}\fbox{\url{https://player.vimeo.com/video/%s}}\end{center}\end{quote}'%node['id'])
+from . import utils
+from functools import partial
 
 
-class Vimeo(Directive):
-    has_content = True
-    required_arguments = 1
-    optional_arguments = 0
-    final_argument_whitespace = False
-    option_spec = {
-        "width": directives.unchanged,
-        "height": directives.unchanged,
-        "aspect": directives.unchanged,
-    }
-
-    def run(self):
-        if "aspect" in self.options:
-            aspect = self.options.get("aspect")
-            m = re.match("(\d+):(\d+)", aspect)
-            if m is None:
-                raise ValueError("invalid aspect ratio %r" % aspect)
-            aspect = tuple(int(x) for x in m.groups())
-        else:
-            aspect = None
-        width = get_size(self.options, "width")
-        height = get_size(self.options, "height")
-        return [vimeo(id=self.arguments[0], aspect=aspect, width=width, height=height)]
+class vimeo(utils.video):
+    pass
 
 
-def unsupported_visit_vimeo(self, node):
-    self.builder.warn('vimeo: unsupported output format (node skipped)')
-    raise nodes.SkipNode
+class Vimeo(utils.Video):
+    _node = vimeo
+
+
+visit_vimeo_node = partial(utils.visit_video_node,
+                           platform_url="https://player.vimeo.com/video/")
+
+
+visit_vimeo_node_latex = partial(utils.visit_video_node_latex,
+                                 platform_url="https://player.vimeo.com/video/")
+
+
+unsupported_visit_vimeo = partial(utils.unsupported_visit_video,
+                                  platform="video")
 
 
 _NODE_VISITORS = {
-    'html': (visit_vimeo_node, depart_youtube_node),
-    'latex': (visit_vimeo_node_latex, depart_youtube_node),
+    'html': (visit_vimeo_node, utils.depart_video_node),
+    'latex': (visit_vimeo_node_latex, utils.depart_video_node),
     'man': (unsupported_visit_vimeo, None),
     'texinfo': (unsupported_visit_vimeo, None),
     'text': (unsupported_visit_vimeo, None)
 }
-
-
-def setup(app):
-    app.add_node(vimeo, **_NODE_VISITORS)
-    app.add_directive("vimeo", vimeo)

--- a/sphinxcontrib/youtube/vimeo.py
+++ b/sphinxcontrib/youtube/vimeo.py
@@ -17,11 +17,12 @@ visit_vimeo_node = partial(utils.visit_video_node,
 
 
 visit_vimeo_node_latex = partial(utils.visit_video_node_latex,
+                                 platform="vimeo",
                                  platform_url="https://player.vimeo.com/video/")
 
 
 unsupported_visit_vimeo = partial(utils.unsupported_visit_video,
-                                  platform="video")
+                                  platform="vimeo")
 
 
 _NODE_VISITORS = {

--- a/sphinxcontrib/youtube/youtube.py
+++ b/sphinxcontrib/youtube/youtube.py
@@ -17,6 +17,7 @@ visit_youtube_node = partial(utils.visit_video_node,
 
 
 visit_youtube_node_latex = partial(utils.visit_video_node_latex,
+                                   platform="youtube",
                                    platform_url="https://youtu.be/")
 
 

--- a/sphinxcontrib/youtube/youtube.py
+++ b/sphinxcontrib/youtube/youtube.py
@@ -1,24 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import re
 from docutils import nodes
 from docutils.parsers.rst import directives, Directive
+from .utils import get_size, css
 
 CONTROL_HEIGHT = 30
-
-def get_size(d, key):
-    if key not in d:
-        return None
-    m = re.match("(\d+)(|%|px)$", d[key])
-    if not m:
-        raise ValueError("invalid size %r" % d[key])
-    return int(m.group(1)), m.group(2) or "px"
-
-def css(d):
-    return "; ".join(sorted("%s: %s" % kv for kv in d.items()))
 
 class youtube(nodes.General, nodes.Element): pass
 
@@ -120,9 +108,4 @@ _NODE_VISITORS = {
     'texinfo': (unsupported_visit_youtube, None),
     'text': (unsupported_visit_youtube, None)
 }
-
-
-def setup(app):
-    app.add_node(youtube, **_NODE_VISITORS)
-    app.add_directive("youtube", YouTube)
 

--- a/sphinxcontrib/youtube/youtube.py
+++ b/sphinxcontrib/youtube/youtube.py
@@ -1,111 +1,33 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from . import utils
+from functools import partial
 
-import re
-from docutils import nodes
-from docutils.parsers.rst import directives, Directive
-from .utils import get_size, css
 
-CONTROL_HEIGHT = 30
-
-class youtube(nodes.General, nodes.Element): pass
-
-def visit_youtube_node(self, node):
-    aspect = node["aspect"]
-    width = node["width"]
-    height = node["height"]
-
-    if aspect is None:
-        aspect = 16, 9
-
-    div_style = {}
-    if (height is None) and (width is not None) and (width[1] == "%"):
-        div_style = {
-            "padding-top": "%dpx" % CONTROL_HEIGHT,
-            "padding-bottom": "%f%%" % (width[0] * aspect[1] / aspect[0]),
-            "width": "%d%s" % width,
-            "position": "relative",
-        }
-        style = {
-            "position": "absolute",
-            "top": "0",
-            "left": "0",
-            "width": "100%",
-            "height": "100%",
-            "border": "0",
-        }
-        attrs = {
-            "src": "https://www.youtube.com/embed/%s" % node["id"],
-            "style": css(style),
-        }
-    else:
-        if width is None:
-            if height is None:
-                width = 560, "px"
-            else:
-                width = height[0] * aspect[0] / aspect[1], "px"
-        if height is None:
-            height = width[0] * aspect[1] / aspect[0], "px"
-        style = {
-            "width": "%d%s" % width,
-            "height": "%d%s" % (height[0] + CONTROL_HEIGHT, height[1]),
-            "border": "0",
-        }
-        attrs = {
-            "src": "https://www.youtube.com/embed/%s" % node["id"],
-            "style": css(style),
-        }
-    attrs["allowfullscreen"] = "true"
-    div_attrs = {
-        "CLASS": "youtube_wrapper",
-        "style": css(div_style),
-    }
-    self.body.append(self.starttag(node, "div", **div_attrs))
-    self.body.append(self.starttag(node, "iframe", **attrs))
-    self.body.append("</iframe></div>")
-
-def depart_youtube_node(self, node):
+class youtube(utils.video):
     pass
 
-def visit_youtube_node_latex(self,node):
-    self.body.append(r'\begin{quote}\begin{center}\fbox{\url{https://youtu.be/%s}}\end{center}\end{quote}'%node['id'])
+
+class YouTube(utils.Video):
+    _node = youtube
 
 
-class YouTube(Directive):
-    has_content = True
-    required_arguments = 1
-    optional_arguments = 0
-    final_argument_whitespace = False
-    option_spec = {
-        "width": directives.unchanged,
-        "height": directives.unchanged,
-        "aspect": directives.unchanged,
-    }
-
-    def run(self):
-        if "aspect" in self.options:
-            aspect = self.options.get("aspect")
-            m = re.match("(\d+):(\d+)", aspect)
-            if m is None:
-                raise ValueError("invalid aspect ratio %r" % aspect)
-            aspect = tuple(int(x) for x in m.groups())
-        else:
-            aspect = None
-        width = get_size(self.options, "width")
-        height = get_size(self.options, "height")
-        return [youtube(id=self.arguments[0], aspect=aspect, width=width, height=height)]
+visit_youtube_node = partial(utils.visit_video_node,
+                             platform_url="https://www.youtube.com/embed/")
 
 
-def unsupported_visit_youtube(self, node):
-    self.builder.warn('youtube: unsupported output format (node skipped)')
-    raise nodes.SkipNode
+visit_youtube_node_latex = partial(utils.visit_video_node_latex,
+                                   platform_url="https://youtu.be/")
+
+
+unsupported_visit_youtube = partial(utils.unsupported_visit_video,
+                                    platform="youtube")
 
 
 _NODE_VISITORS = {
-    'html': (visit_youtube_node, depart_youtube_node),
-    'latex': (visit_youtube_node_latex, depart_youtube_node),
+    'html': (visit_youtube_node, utils.depart_video_node),
+    'latex': (visit_youtube_node_latex, utils.depart_video_node),
     'man': (unsupported_visit_youtube, None),
     'texinfo': (unsupported_visit_youtube, None),
     'text': (unsupported_visit_youtube, None)
 }
-


### PR DESCRIPTION
It turns out that supporting Vimeo is nearly identical to supporting YouTube, you just change the URL in the right places. This PR refactors the plugin into `utils.py`, which contains a generic version of the code, and `youtube.py` and `vimeo.py` which specialise the code for the different platforms.

Along the way, provide a much more customisable version of LaTeX output, which enables the user to do almost anything with the youtube or vimeo link by defining a single LaTeX macro.

Update the documentation.