### PR TITLE
Adding a "hide" parameter to increase privacy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,19 @@ parameters "aspect", "width", and "height" may optionally be provided::
     ..  youtube:: oHg5SJYRHA0
         :height: 200px
 
+You can increase privacy for users of your HTML output by hiding the embedded
+video behind a button. If used, connection to the video platform will be
+made only if the button is clicked. You can enable this by using the "hide"
+parameter. It accepts 'False' (default) or 'True' or any <string>. If a 
+<string> is used then the video will be hidden and the button will show text
+"Display: <string>" ::
+
+    .. youtube:: oHg5SJYRHA0
+       :hide: True
+    
+    .. youtube:: oHg5SJYRHA0
+       :hide: Video title to show it on the button
+
 A simple link to the video, enclosed in a box, will be inserted in LaTeX output.
 
 ..  -*- mode: rst; fill-column: 72 -*-

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import re
-from typing_extensions import TypeVarTuple
 from docutils import nodes
 from docutils.parsers.rst import directives, Directive
 

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -94,7 +94,7 @@ def visit_video_node(self, node, platform_url):
     self.body.append(self.starttag(node, "iframe", **attrs))
     self.body.append("</iframe></div>")
     if hide:
-        self.body.append(f'<button onclick=\"document.getElementsByName(\"{node["id"]}\")[0].style.display = \"block\"; this.style.display = \"none\">{hide}</button></section>')
+        self.body.append(f'\n<button onclick=\'document.getElementsByName(\"{node["id"]}\")[0].style.display = \"block\"; this.style.display = \"none\"\'>{hide}</button></section>')
 
 
 def depart_video_node(self, node):


### PR DESCRIPTION
Embedding YouTube videos on an HTML page as a side-effect of decreasing privacy for users. Leaving the (mis)use of cookies aside, even the act of loading a page with an embedded video is detrimental to privacy because the server(s) of the hosting platform is contacted to fetch the embedded element.

As a solution, I have implemented a "hide" parameter that marks the `div` of every video with `style.display = "none"` and adds an HTML button to flip this to `style.display = "block"`. Once clicked, the embed video appears and the button disappears.

I have tried to make the parameter a bit more versatile than a simple Boolean value. It can take in `True`, `False` or a title string for the video that's hidden behind the button.

A preview of things look like with the parameter is as follows:

When no title is given (i.e. `hide: True`):
![WhenTitleIsNotGiven](https://user-images.githubusercontent.com/45761248/122089600-d393d400-cdfe-11eb-9851-52d3b8877e97.png)

When no title is given (i.e. `hide: Here's the title of my video`):
![WhenTitleIsGiven](https://user-images.githubusercontent.com/45761248/122089734-f8884700-cdfe-11eb-9135-72beb7681f06.png)

When the parameter is not used, or set to False, or when the button has been clicked:
![AfterClicking](https://user-images.githubusercontent.com/45761248/122089749-fc1bce00-cdfe-11eb-9a4f-05f9f9e1958c.png)
