### PR TITLE
Timestamp support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,15 @@ parameters "aspect", "width", and "height" may optionally be provided::
     ..  youtube:: oHg5SJYRHA0
         :height: 200px
 
+To start the video at a specific timestamp the parameter "timestamp" may
+optionally be provided::
+
+    ..  youtube:: oHg5SJYRHA0
+        :timestamp: 300
+
+    .. vimeo:: 73214621
+        :timestamp: 3m13s
+
 In LaTeX output, the followinging code will be emitted for YouTube::
 
     \sphinxcontribyoutube{https://youtu.be/}{oHg5SJYRHA0}

--- a/README.rst
+++ b/README.rst
@@ -31,23 +31,23 @@ parameters "aspect", "width", and "height" may optionally be provided::
     ..  youtube:: oHg5SJYRHA0
         :height: 200px
 
-To start the video at a specific timestamp the parameter "timestamp" may
-optionally be provided::
+To start the video at a specific time the parameter "url_parameters" may be used
+(quotes required for Vimeo videos)::
 
     ..  youtube:: oHg5SJYRHA0
-        :timestamp: 300
+        :url_parameters: ?start=300
 
     .. vimeo:: 73214621
-        :timestamp: 3m13s
+        :url_parameters: "#t=3m13s"
 
-In LaTeX output, the followinging code will be emitted for YouTube::
+In LaTeX output, the following code will be emitted for YouTube::
 
-    \sphinxcontribyoutube{https://youtu.be/}{oHg5SJYRHA0}
+    \sphinxcontribyoutube{https://youtu.be/}{oHg5SJYRHA0}{?start=300}
 
 The user may customise the rendering of the URL by defining this command in 
 the premble. If they do not, then the default definition is used::
 
-    \newcommand{\sphinxcontribvimeo}[2]{\begin{quote}\begin{center}\fbox{\url{#1#2}}\end{center}\end{quote}}
+    \newcommand{\sphinxcontribvimeo}[2]{\begin{quote}\begin{center}\fbox{\url{#1#2#3}}\end{center}\end{quote}}
 
 This prints a simple link to the video, enclosed in a box. LaTeX support for
 Vimeo is similar, except that the macro is named `\sphinxcontribvimeo`.

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ In LaTeX output, the following code will be emitted for YouTube::
 The user may customise the rendering of the URL by defining this command in 
 the premble. If they do not, then the default definition is used::
 
-    \newcommand{\sphinxcontribvimeo}[2]{\begin{quote}\begin{center}\fbox{\url{#1#2#3}}\end{center}\end{quote}}
+    \newcommand{\sphinxcontribvimeo}[3]{\begin{quote}\begin{center}\fbox{\url{#1#2#3}}\end{center}\end{quote}}
 
 This prints a simple link to the video, enclosed in a box. LaTeX support for
 Vimeo is similar, except that the macro is named `\sphinxcontribvimeo`.

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -38,7 +38,7 @@ def visit_video_node(self, node, platform_url):
         if "vimeo" in platform_url:
             timestamp_url = f"#t={timestamp}"
         else:
-            timestamp_url = f"?t={timestamp}"
+            timestamp_url = f"?start={timestamp}"
     else:
         timestamp_url = ""
 

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -89,7 +89,7 @@ def visit_video_node_latex(self, node, platform, platform_url):
     macro = r"\sphinxcontrib%s" % platform
     if macro not in self.elements["preamble"]:
         self.elements["preamble"] += r"""
-        \newcommand{%s}[2]{\begin{quote}\begin{center}\fbox{\url{#1#2#3}}\end{center}\end{quote}}
+        \newcommand{%s}[3]{\begin{quote}\begin{center}\fbox{\url{#1#2#3}}\end{center}\end{quote}}
         """ % macro
     self.body.append('%s{%s}{%s}{%s}\n' % (macro, platform_url, node['id'], node['url_parameters']))
 

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -29,9 +29,18 @@ def visit_video_node(self, node, platform_url):
     aspect = node["aspect"]
     width = node["width"]
     height = node["height"]
+    timestamp = node["timestamp"]
 
     if aspect is None:
         aspect = 16, 9
+
+    if timestamp is not None:
+        if "vimeo" in platform_url:
+            timestamp_url = f"#t={timestamp}"
+        else:
+            timestamp_url = f"?t={timestamp}"
+    else:
+        timestamp_url = ""
 
     div_style = {}
     if (height is None) and (width is not None) and (width[1] == "%"):
@@ -50,7 +59,7 @@ def visit_video_node(self, node, platform_url):
             "border": "0",
         }
         attrs = {
-            "src": f"{platform_url}{node['id']}",
+            "src": f"{platform_url}{node['id']}{timestamp_url}",
             "style": css(style),
         }
     else:
@@ -103,6 +112,7 @@ class Video(Directive):
         "width": directives.unchanged,
         "height": directives.unchanged,
         "aspect": directives.unchanged,
+        "timestamp": directives.unchanged,
     }
 
     def run(self):
@@ -116,7 +126,8 @@ class Video(Directive):
             aspect = None
         width = get_size(self.options, "width")
         height = get_size(self.options, "height")
-        return [self._node(id=self.arguments[0], aspect=aspect, width=width, height=height)]
+        timestamp = self.options.get("timestamp", None)
+        return [self._node(id=self.arguments[0], aspect=aspect, width=width, height=height, timestamp=timestamp)]
 
 
 def unsupported_visit_video(self, node, platform):

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -29,18 +29,10 @@ def visit_video_node(self, node, platform_url):
     aspect = node["aspect"]
     width = node["width"]
     height = node["height"]
-    timestamp = node["timestamp"]
+    url_parameters = node["url_parameters"]
 
     if aspect is None:
         aspect = 16, 9
-
-    if timestamp is not None:
-        if "vimeo" in platform_url:
-            timestamp_url = "#t={}".format(timestamp)
-        else:
-            timestamp_url = "?start={}".format(timestamp)
-    else:
-        timestamp_url = ""
 
     div_style = {}
     if (height is None) and (width is not None) and (width[1] == "%"):
@@ -59,7 +51,7 @@ def visit_video_node(self, node, platform_url):
             "border": "0",
         }
         attrs = {
-            "src": "{}{}{}".format(platform_url,node['id'],timestamp_url),
+            "src": "{}{}{}".format(platform_url,node['id'],url_parameters),
             "style": css(style),
         }
     else:
@@ -97,9 +89,9 @@ def visit_video_node_latex(self, node, platform, platform_url):
     macro = r"\sphinxcontrib%s" % platform
     if macro not in self.elements["preamble"]:
         self.elements["preamble"] += r"""
-        \newcommand{%s}[2]{\begin{quote}\begin{center}\fbox{\url{#1#2}}\end{center}\end{quote}}
+        \newcommand{%s}[2]{\begin{quote}\begin{center}\fbox{\url{#1#2#3}}\end{center}\end{quote}}
         """ % macro
-    self.body.append('%s{%s}{%s}\n' % (macro, platform_url, node['id']))
+    self.body.append('%s{%s}{%s}{%s}\n' % (macro, platform_url, node['id'], node['url_parameters']))
 
 
 class Video(Directive):
@@ -112,13 +104,13 @@ class Video(Directive):
         "width": directives.unchanged,
         "height": directives.unchanged,
         "aspect": directives.unchanged,
-        "timestamp": directives.unchanged,
+        "url_parameters": directives.unchanged,
     }
 
     def run(self):
         if "aspect" in self.options:
             aspect = self.options.get("aspect")
-            m = re.match("(\d+):(\d+)", aspect)
+            m = re.match(r"(\d+):(\d+)", aspect)
             if m is None:
                 raise ValueError("invalid aspect ratio %r" % aspect)
             aspect = tuple(int(x) for x in m.groups())
@@ -126,8 +118,8 @@ class Video(Directive):
             aspect = None
         width = get_size(self.options, "width")
         height = get_size(self.options, "height")
-        timestamp = self.options.get("timestamp", None)
-        return [self._node(id=self.arguments[0], aspect=aspect, width=width, height=height, timestamp=timestamp)]
+        url_parameters = self.options.get("url_parameters", "")
+        return [self._node(id=self.arguments[0], aspect=aspect, width=width, height=height, url_parameters=url_parameters)]
 
 
 def unsupported_visit_video(self, node, platform):


### PR DESCRIPTION
Adding optional parameter `:timestamp:` for both YouTube and Vimeo
videos.

Fixes https://github.com/sphinx-contrib/youtube/issues/17