### PR TITLE
Fixes for compatibility

### DIFF
--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -50,7 +50,7 @@ def visit_video_node(self, node, platform_url):
             "border": "0",
         }
         attrs = {
-            "src": f"{platform_url}{node['id']}",
+            "src": "{}{}".format(platform_url,node['id']),
             "style": css(style),
         }
     else:
@@ -67,7 +67,7 @@ def visit_video_node(self, node, platform_url):
             "border": "0",
         }
         attrs = {
-            "src":  f"{platform_url}{node['id']}",
+            "src":  "{}{}".format(platform_url,node['id']),
             "style": css(style),
         }
     attrs["allowfullscreen"] = "true"
@@ -120,5 +120,5 @@ class Video(Directive):
 
 
 def unsupported_visit_video(self, node, platform):
-    self.builder.warn(f'{platform}: unsupported output format (node skipped)')
+    self.builder.warn('{}: unsupported output format (node skipped)'.format(platform))
     raise nodes.SkipNode

--- a/sphinxcontrib/youtube/vimeo.py
+++ b/sphinxcontrib/youtube/vimeo.py
@@ -12,17 +12,16 @@ class Vimeo(utils.Video):
     _node = vimeo
 
 
-visit_vimeo_node = partial(utils.visit_video_node,
-                           platform_url="https://player.vimeo.com/video/")
+def visit_vimeo_node(self, node):
+    return utils.visit_video_node(self, node, platform_url="https://player.vimeo.com/video/")
 
 
-visit_vimeo_node_latex = partial(utils.visit_video_node_latex,
-                                 platform="vimeo",
-                                 platform_url="https://player.vimeo.com/video/")
+def visit_vimeo_node_latex(self, node):
+    return utils.visit_video_node_latex(self, node, platform="vimeo", platform_url="https://player.vimeo.com/video/")
 
 
-unsupported_visit_vimeo = partial(utils.unsupported_visit_video,
-                                  platform="vimeo")
+def unsupported_visit_vimeo(self, node):
+    return utils.unsupported_visit_video(self, node, platform="vimeo")
 
 
 _NODE_VISITORS = {

--- a/sphinxcontrib/youtube/vimeo.py
+++ b/sphinxcontrib/youtube/vimeo.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from . import utils
-from functools import partial
 
 
 class vimeo(utils.video):

--- a/sphinxcontrib/youtube/youtube.py
+++ b/sphinxcontrib/youtube/youtube.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from . import utils
-from functools import partial
 
 
 class youtube(utils.video):

--- a/sphinxcontrib/youtube/youtube.py
+++ b/sphinxcontrib/youtube/youtube.py
@@ -12,17 +12,16 @@ class YouTube(utils.Video):
     _node = youtube
 
 
-visit_youtube_node = partial(utils.visit_video_node,
-                             platform_url="https://www.youtube.com/embed/")
+def visit_youtube_node(self, node):
+    return utils.visit_video_node(self, node, platform_url="https://www.youtube.com/embed/")
 
 
-visit_youtube_node_latex = partial(utils.visit_video_node_latex,
-                                   platform="youtube",
-                                   platform_url="https://youtu.be/")
+def visit_youtube_node_latex(self, node):
+    return utils.visit_video_node_latex(self, node, platform="youtube", platform_url="https://youtu.be/")
 
 
-unsupported_visit_youtube = partial(utils.unsupported_visit_video,
-                                    platform="youtube")
+def unsupported_visit_youtube(self, node):
+    return utils.unsupported_visit_video(self, node, platform="youtube")
 
 
 _NODE_VISITORS = {


### PR DESCRIPTION
These are 2 commits that solve issues when building with python 2, 3.5, and others. Python f strings were added in 3.5. Using a function wrapper without functools.partial creates the proper attributes that docutils nodes.py is looking for and matches the example nodes from sphinx.

Solves `AttributeError: 'functools.partial' object has no attribute '__name__'` error from docutils nodes.py

Tested with the ArduPilot documentation using python 2 and 3.