### PR TITLE
Add align parameter to YouTube directive.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,13 @@ parameters "aspect", "width", and "height" may optionally be provided::
     ..  youtube:: oHg5SJYRHA0
         :height: 200px
 
+To set the alignment of the embedded video's iframe in the HTML output, an 
+optional "align" parameter can be specified, similar to the rst :image: 
+directive::
+
+    ..  youtube:: oHg5SJYRHA0
+        :align: center
+
 In LaTeX output, the followinging code will be emitted for YouTube::
 
     \sphinxcontribyoutube{https://youtu.be/}{oHg5SJYRHA0}

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -75,6 +75,7 @@ def visit_video_node(self, node, platform_url):
         "CLASS": "video_wrapper",
         "style": css(div_style),
     }
+    if node["align"] != None: div_attrs["CLASS"] += " align-%s" % node["align"]
     self.body.append(self.starttag(node, "div", **div_attrs))
     self.body.append(self.starttag(node, "iframe", **attrs))
     self.body.append("</iframe></div>")
@@ -103,6 +104,7 @@ class Video(Directive):
         "width": directives.unchanged,
         "height": directives.unchanged,
         "aspect": directives.unchanged,
+        "align": directives.unchanged,
     }
 
     def run(self):
@@ -114,9 +116,16 @@ class Video(Directive):
             aspect = tuple(int(x) for x in m.groups())
         else:
             aspect = None
+        if "align" in self.options:
+            align = self.options.get("align")
+            if align not in ["left", "center", "right"]:
+                raise ValueError(
+                    "invalid alignment. choices are [\"left\", \"center\", \"right\"]")
+        else:
+            align = None
         width = get_size(self.options, "width")
         height = get_size(self.options, "height")
-        return [self._node(id=self.arguments[0], aspect=aspect, width=width, height=height)]
+        return [self._node(id=self.arguments[0], aspect=aspect, width=width, height=height, align=align)]
 
 
 def unsupported_visit_video(self, node, platform):

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -70,6 +70,7 @@ def visit_video_node(self, node, platform_url):
             "src":  "{}{}".format(platform_url,node['id']),
             "style": css(style),
         }
+    if node["align"] != None: div_style["text-align"] = node["align"]
     attrs["allowfullscreen"] = "true"
     div_attrs = {
         "CLASS": "video_wrapper",


### PR DESCRIPTION
The optional :align: option controls the alignment of the embedded iframe, similar to the rst image's directive's :align:.

https://docutils.sourceforge.io/docs/ref/rst/directives.html#image

I wasn't sure what to do with the LaTeX builder, but I figured that option would be unnecessary since alignment is already controllable in the generated preamble command.