### PR TITLE
download the thumbnails from the ID

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,27 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - epub
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+      - doc

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ In LaTeX output, the following code will be emitted for the videos:
 
    \sphinxcontribvimeo{https://player.vimeo.com/video/}{148751763}{"#t=0m43s"}
 
-The user may customise the rendering of the URL by defining this command in the preamble. The captions will be downloaded to the latex folder and can thus be used as images in the :code:`.pdf` document. Here is an example of custom command for both the vimeo and the yoututbe output. This need to be added in the :code:`conf.py` file:
+The user may customise the rendering of the URL by defining this command in the preamble. The captions will be downloaded to the latex folder and can thus be used as images in the :code:`.pdf` document. Here is an example of custom command for both the vimeo and the yoututbe output. This needs to be added in the :code:`conf.py` file:
 
 .. code-block:: python
 
@@ -101,7 +101,7 @@ The user may customise the rendering of the URL by defining this command in the 
  
    latex_elements = {"preamble": youtube_cmd + vimeo_cmd}
 
-This example will show the video as a figure using the thumbnail as image and the url as caption (clickable link). This is the one we use for this very documentation. rember that the argument of your command are the following:
+This example will show the video as a figure using the thumbnail as image and the url as caption (clickable link). This is the one we use for this very documentation. remember that the argument of your command are the following:
 
 -   :code:`#1`: the platform url
 -   :code:`#2`: the video ID (it's also the name of the image: :code:`#2.jpg`

--- a/README.rst
+++ b/README.rst
@@ -103,9 +103,9 @@ The user may customise the rendering of the URL by defining this command in the 
 
 This example will show the video as a figure using the thumbnail as image and the url as caption (clickable link). This is the one we use for this very documentation. rember that the argument of your command are the following:
 
--   #1: the platform url
--   #2: the video ID (it's also the name of the image: :code:`#2.jpg`
--   #3: the options of the url
+-   :code:`#1`: the platform url
+-   :code:`#2`: the video ID (it's also the name of the image: :code:`#2.jpg`
+-   :code:`#3`: the options of the url
 
 If no custom command is set in :code:`conf.py`, then the default definition is used:
 

--- a/README.rst
+++ b/README.rst
@@ -9,65 +9,108 @@ sphinxcontrib.youtube
     :target: https://badge.fury.io/py/sphinxcontrib-youtube
     :alt: PyPi version 
 
-This module provides support for including YouTube and Vimeo videos
-in Sphinx rst documents.
+Overview
+--------
 
-This module defines directives, `youtube` and `vimeo` which insert videos
-from the respective platforms. They take a single, required argument, a 
-YouTube video ID::
+This module provides support for including YouTube and Vimeo videos in Sphinx :code:`rst` documents.
 
-    ..  youtube:: oHg5SJYRHA0
+This module defines directives, :code:`youtube` and :code:`vimeo` which insert videos from the respective platforms. They take a single, required argument, wich is the video ID: 
 
-or a Vimeo video ID::
+.. code-block:: rst 
+   
+   ..  youtube:: dQw4w9WgXcQ
 
-    .. vimeo:: 486106801
+.. code-block:: rst
 
-The referenced video will be embedded into HTML output.  By default, the
-embedded video will be sized for 720p content.  To control this, the
-parameters "aspect", "width", and "height" may optionally be provided::
+   .. vimeo:: 148751763
 
-    ..  youtube:: oHg5SJYRHA0
-        :width: 640
-        :height: 480
+Usage
+-----
 
-    ..  youtube:: oHg5SJYRHA0
-        :aspect: 4:3
+The referenced video will be embedded into HTML and Latex outputs, the behaviour will be slighly different for obvious reasons.
 
-    ..  youtube:: oHg5SJYRHA0
-        :width: 100%
+HTML
+^^^^
 
-    ..  youtube:: oHg5SJYRHA0
-        :height: 200px
+By default, the embedded video will be sized for 720p content. To control this, the parameters :code:`aspect`, :code:`width`, and :code:`height` may optionally be provided:
 
-To set the alignment of the embedded video's iframe in the HTML output, an 
-optional "align" parameter can be specified, similar to the rst :image: 
-directive::
+.. code-block:: rst
 
-    ..  youtube:: oHg5SJYRHA0
-        :align: center
+   ..  youtube:: dQw4w9WgXcQ
+      :width: 640
+      :height: 480
 
-To start the video at a specific time the parameter "url_parameters" may be used
-(quotes required for Vimeo videos)::
+.. code-block:: rst
 
-    ..  youtube:: oHg5SJYRHA0
-        :url_parameters: ?start=300
+   ..  youtube:: dQw4w9WgXcQ
+      :aspect: 4:3
 
-    .. vimeo:: 73214621
-        :url_parameters: "#t=3m13s"
+.. code-block:: rst
 
-In LaTeX output, the following code will be emitted for YouTube::
+   ..  youtube:: dQw4w9WgXcQ
+      :width: 100%
 
-    \sphinxcontribyoutube{https://youtu.be/}{oHg5SJYRHA0}{?start=300}
+.. code-block:: rst
 
-The user may customise the rendering of the URL by defining this command in 
-the premble. If they do not, then the default definition is used::
+   ..  youtube:: dQw4w9WgXcQ
+      :height: 200px
+
+To set the alignment of the embedded video's iframe in the HTML output, an optional :code:`align` parameter can be specified, similar to the rst :code:`image` directive:
+
+.. code-block:: rst
+
+   ..  youtube:: dQw4w9WgXcQ
+      :align: center
+
+To start the video at a specific time the parameter "url_parameters" may be used (quotes required for Vimeo videos):
+
+.. code-block:: rst
+
+   ..  youtube:: dQw4w9WgXcQ
+      :url_parameters: ?start=43
+
+.. code-block:: rst
+
+   .. vimeo:: 148751763
+      :url_parameters: "#t=0m43s"
+
+Latex
+^^^^^
+
+In LaTeX output, the following code will be emitted for the videos:
+
+.. code-block:: latex
+
+   \sphinxcontribyoutube{https://youtu.be/}{dQw4w9WgXcQ}{?start=43}
+
+.. code-block:: latex
+
+   \sphinxcontribvimeo{https://player.vimeo.com/video/}{148751763}{"#t=0m43s"}
+
+The user may customise the rendering of the URL by defining this command in the preamble. The captions will be downloaded to the latex folder and can thus be used as images in the :code:`.pdf` document. Here is an example of custom command for both the vimeo and the yoututbe output. This need to be added in the :code:`conf.py` file:
+
+.. code-block:: python
+
+   # conf.py 
+   # ...
+   # -- Option for Latex output ---------------------------------------------------
+
+   # create a custom sphinx output for the youtube and vimeo video
+   youtube_cmd = r"\newcommand{\sphinxcontribyoutube}[3]{\begin{figure}\sphinxincludegraphics{{#2}.jpg}\caption{\url{#1#2#3}}\end{figure}}" + "\n"
+   vimeo_cmd = r"\newcommand{\sphinxcontribvimeo}[3]{\begin{figure}\sphinxincludegraphics{{#2}.jpg}\caption{\url{#1#2#3}}\end{figure}}" + "\n"
+ 
+   latex_elements = {"preamble": youtube_cmd + vimeo_cmd}
+
+This example will show the video as a figure using the thumbnail as image and the url as caption (clickable link). This is the one we use for this very documentation. rember that the argument of your command are the following:
+
+-   #1: the platform url
+-   #2: the video ID (it's also the name of the image: :code:`#2.jpg`
+-   #3: the options of the url
+
+If no custom command is set in :code:`conf.py`, then the default definition is used:
+
+.. code-block:: latex
 
     \newcommand{\sphinxcontribyoutube}[3]{\begin{quote}\begin{center}\fbox{\url{#1#2#3}}\end{center}\end{quote}}
 
-This prints a simple link to the video, enclosed in a box. LaTeX support for
-Vimeo is similar, except that the macro is named `\sphinxcontribvimeo`.
-
-**Note:** The third argument to this macro was introduced in version 1.1. Prior
-to this only the first two arguments were passed.
-
-..  -*- mode: rst; fill-column: 79 -*-
+This prints a simple link to the video, enclosed in a box. LaTeX support for Vimeo is similar, except that the macro is named :code:`\sphinxcontribvimeo`.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,7 +4,7 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
+# -- Path setup ----------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -16,7 +16,7 @@
 from datetime import datetime
 
 
-# -- Project information -----------------------------------------------------
+# -- Project information -------------------------------------------------------
 
 project = 'sphinxcontrib-youtube'
 author = 'Dr David Ham, Chris Pickel and others'
@@ -26,7 +26,7 @@ copyright = f'2011-{datetime.now().year}, {author}'
 release = '1.1.0'
 
 
-# -- General configuration ---------------------------------------------------
+# -- General configuration -----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -45,7 +45,7 @@ templates_path = ['_templates']
 exclude_patterns = ["**.ipynb_checkpoints"]
 
 
-# -- Options for HTML output -------------------------------------------------
+# -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
@@ -56,3 +56,12 @@ html_theme = "furo"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+
+# -- Option for Latex output ---------------------------------------------------
+
+# create a custom sphinx output for the youtube and vimeo video
+youtube_cmd = r"\newcommand{\sphinxcontribyoutube}[3]{\begin{figure}\sphinxincludegraphics{{#2}.jpg}\caption{\url{#1#2#3}}\end{figure}}" + "\n"
+vimeo_cmd = r"\newcommand{\sphinxcontribvimeo}[3]{\begin{figure}\sphinxincludegraphics{{#2}.jpg}\caption{\url{#1#2#3}}\end{figure}}" + "\n"
+ 
+latex_elements = {"preamble": youtube_cmd + vimeo_cmd}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,58 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+from datetime import datetime
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'sphinxcontrib-youtube'
+author = 'Dr David Ham, Chris Pickel and others'
+copyright = f'2011-{datetime.now().year}, {author}'
+
+# The full version, including alpha/beta/rc tags
+release = '1.1.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx_copybutton",
+    "sphinxcontrib.youtube"
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["**.ipynb_checkpoints"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "furo"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -87,7 +87,7 @@ In LaTeX output, the following code will be emitted for the videos:
 
    \sphinxcontribvimeo{https://player.vimeo.com/video/}{148751763}{"#t=0m43s"}
 
-The user may customise the rendering of the URL by defining this command in the preamble. The captions will be downloaded to the latex folder and can thus be used as images in the :code:`.pdf` document. Here is an example of custom command for both the vimeo and the yoututbe output. This need to be added in the :code:`conf.py` file:
+The user may customise the rendering of the URL by defining this command in the preamble. The captions will be downloaded to the latex folder and can thus be used as images in the :code:`.pdf` document. We are using the `https://vumbnail.com`__ (vimeo) and `https://www.get-youtube-thumbnail.com`__ (youtube) web services to retrieve them. Here is an example of custom command for both the vimeo and the yoututbe output. This need to be added in the :code:`conf.py` file:
 
 .. code-block:: python
 
@@ -103,9 +103,9 @@ The user may customise the rendering of the URL by defining this command in the 
 
 This example will show the video as a figure using the thumbnail as image and the url as caption (clickable link). This is the one we use for this very documentation. rember that the argument of your command are the following:
 
--   #1: the platform url
--   #2: the video ID (it's also the name of the image: :code:`#2.jpg`
--   #3: the options of the url
+-   :code:`#1`: the platform url
+-   :code:`#2`: the video ID (it's also the name of the image: :code:`#2.jpg`
+-   :code:`#3`: the options of the url
 
 If no custom command is set in :code:`conf.py`, then the default definition is used:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,30 +4,35 @@ sphinxcontrib-youtube
 Demo
 ----
 
-This module provides support for including YouTube and Vimeo videos in Sphinx rst documents.
+This module provides support for including YouTube and Vimeo videos in Sphinx :code:`rst` documents.
 
-This module defines directives, code:`youtube` and :code:`vimeo` which insert videos from the respective platforms. They take a single, required argument, wich is the video ID: 
+This module defines directives, :code:`youtube` and :code:`vimeo` which insert videos from the respective platforms. They take a single, required argument, wich is the video ID: 
 
 .. code-block:: rst 
    
    ..  youtube:: dQw4w9WgXcQ
 
+..  youtube:: dQw4w9WgXcQ
+   :align: center
+   :aspect: 16:9
+
 .. code-block:: rst
 
    .. vimeo:: 148751763
 
-..  youtube:: dQw4w9WgXcQ
-
 .. vimeo:: 148751763
+   :align: center
+   :aspect: 16:9
 
 Usage
 -----
 
+The referenced video will be embedded into HTML and Latex outputs, the behaviour will be slighly different for obvious reasons.
+
 HTML
 ^^^^
 
-The referenced video will be embedded into HTML and Latex outputs.  By default, the embedded video will be sized for 720p content. To control this, the
-parameters :code:`aspect`, :code:`width`, and :code:`height` may optionally be provided:
+By default, the embedded video will be sized for 720p content. To control this, the parameters :code:`aspect`, :code:`width`, and :code:`height` may optionally be provided:
 
 .. code-block:: rst
 
@@ -82,7 +87,27 @@ In LaTeX output, the following code will be emitted for the videos:
 
    \sphinxcontribvimeo{https://player.vimeo.com/video/}{148751763}{"#t=0m43s"}
 
-The user may customise the rendering of the URL by defining this command in the preamble. If they do not, then the default definition is used:
+The user may customise the rendering of the URL by defining this command in the preamble. The captions will be downloaded to the latex folder and can thus be used as images in the :code:`.pdf` document. Here is an example of custom command for both the vimeo and the yoututbe output. This need to be added in the :code:`conf.py` file:
+
+.. code-block:: python
+
+   # conf.py 
+   # ...
+   # -- Option for Latex output ---------------------------------------------------
+
+   # create a custom sphinx output for the youtube and vimeo video
+   youtube_cmd = r"\newcommand{\sphinxcontribyoutube}[3]{\begin{figure}\sphinxincludegraphics{{#2}.jpg}\caption{\url{#1#2#3}}\end{figure}}" + "\n"
+   vimeo_cmd = r"\newcommand{\sphinxcontribvimeo}[3]{\begin{figure}\sphinxincludegraphics{{#2}.jpg}\caption{\url{#1#2#3}}\end{figure}}" + "\n"
+ 
+   latex_elements = {"preamble": youtube_cmd + vimeo_cmd}
+
+This example will show the video as a figure using the thumbnail as image and the url as caption (clickable link). This is the one we use for this very documentation. rember that the argument of your command are the following:
+
+-   #1: the platform url
+-   #2: the video ID (it's also the name of the image: :code:`#2.jpg`
+-   #3: the options of the url
+
+If no custom command is set in :code:`conf.py`, then the default definition is used:
 
 .. code-block:: latex
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,8 @@ This module defines directives, code:`youtube` and :code:`vimeo` which insert vi
 
    .. vimeo:: 148751763
 
+..  youtube:: dQw4w9WgXcQ
+
 .. vimeo:: 148751763
 
 Usage

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -61,6 +61,13 @@ To set the alignment of the embedded video's iframe in the HTML output, an optio
 
    ..  youtube:: dQw4w9WgXcQ
       :align: center
+      
+For YouTube "privacy mode", use the directive option :privacy_mode: (and for vimeo, :url_parameters: ?dnt=1):
+
+.. code-block:: rst
+   
+   ..  youtube:: dQw4w9WgXcQ
+      :privacy_mode:
 
 To start the video at a specific time the parameter "url_parameters" may be used (quotes required for Vimeo videos):
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -87,7 +87,7 @@ In LaTeX output, the following code will be emitted for the videos:
 
    \sphinxcontribvimeo{https://player.vimeo.com/video/}{148751763}{"#t=0m43s"}
 
-The user may customise the rendering of the URL by defining this command in the preamble. The captions will be downloaded to the latex folder and can thus be used as images in the :code:`.pdf` document. We are using the `https://vumbnail.com`__ (vimeo) and `https://www.get-youtube-thumbnail.com`__ (youtube) web services to retrieve them. Here is an example of custom command for both the vimeo and the yoututbe output. This need to be added in the :code:`conf.py` file:
+The user may customise the rendering of the URL by defining this command in the preamble. The captions will be downloaded to the latex folder and can thus be used as images in the :code:`.pdf` document. We are using the `https://vumbnail.com`__ (vimeo) and `https://www.get-youtube-thumbnail.com`__ (youtube) web services to retrieve them. Here is an example of custom command for both the vimeo and the yoututbe output. This needs to be added in the :code:`conf.py` file:
 
 .. code-block:: python
 
@@ -101,7 +101,7 @@ The user may customise the rendering of the URL by defining this command in the 
  
    latex_elements = {"preamble": youtube_cmd + vimeo_cmd}
 
-This example will show the video as a figure using the thumbnail as image and the url as caption (clickable link). This is the one we use for this very documentation. rember that the argument of your command are the following:
+This example will show the video as a figure using the thumbnail as image and the url as caption (clickable link). This is the one we use for this very documentation. remember that the argument of your command are the following:
 
 -   :code:`#1`: the platform url
 -   :code:`#2`: the video ID (it's also the name of the image: :code:`#2.jpg`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,93 @@
+sphinxcontrib-youtube
+=====================
+
+Demo
+----
+
+This module provides support for including YouTube and Vimeo videos in Sphinx rst documents.
+
+This module defines directives, code:`youtube` and :code:`vimeo` which insert videos from the respective platforms. They take a single, required argument, wich is the video ID: 
+
+.. code-block:: rst 
+   
+   ..  youtube:: dQw4w9WgXcQ
+
+.. code-block:: rst
+
+   .. vimeo:: 148751763
+
+.. vimeo:: 148751763
+
+Usage
+-----
+
+HTML
+^^^^
+
+The referenced video will be embedded into HTML and Latex outputs.  By default, the embedded video will be sized for 720p content. To control this, the
+parameters :code:`aspect`, :code:`width`, and :code:`height` may optionally be provided:
+
+.. code-block:: rst
+
+   ..  youtube:: dQw4w9WgXcQ
+      :width: 640
+      :height: 480
+
+.. code-block:: rst
+
+   ..  youtube:: dQw4w9WgXcQ
+      :aspect: 4:3
+
+.. code-block:: rst
+
+   ..  youtube:: dQw4w9WgXcQ
+      :width: 100%
+
+.. code-block:: rst
+
+   ..  youtube:: dQw4w9WgXcQ
+      :height: 200px
+
+To set the alignment of the embedded video's iframe in the HTML output, an optional :code:`align` parameter can be specified, similar to the rst :code:`image` directive:
+
+.. code-block:: rst
+
+   ..  youtube:: dQw4w9WgXcQ
+      :align: center
+
+To start the video at a specific time the parameter "url_parameters" may be used (quotes required for Vimeo videos):
+
+.. code-block:: rst
+
+   ..  youtube:: dQw4w9WgXcQ
+      :url_parameters: ?start=43
+
+.. code-block:: rst
+
+   .. vimeo:: 148751763
+      :url_parameters: "#t=0m43s"
+
+Latex
+^^^^^
+
+In LaTeX output, the following code will be emitted for the videos:
+
+.. code-block:: latex
+
+   \sphinxcontribyoutube{https://youtu.be/}{dQw4w9WgXcQ}{?start=43}
+
+.. code-block:: latex
+
+   \sphinxcontribvimeo{https://player.vimeo.com/video/}{148751763}{"#t=0m43s"}
+
+The user may customise the rendering of the URL by defining this command in the preamble. If they do not, then the default definition is used:
+
+.. code-block:: latex
+
+    \newcommand{\sphinxcontribyoutube}[3]{\begin{quote}\begin{center}\fbox{\url{#1#2#3}}\end{center}\end{quote}}
+
+This prints a simple link to the video, enclosed in a box. LaTeX support for Vimeo is similar, except that the macro is named :code:`\sphinxcontribvimeo`.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ YouTube and Vimeo videos, respectively.
 '''
 
 requires = ['Sphinx>=0.6']
+doc_requires = ["sphinx-copybutton", "furo"]
 
 setup(
     name='sphinxcontrib-youtube',
@@ -38,5 +39,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=requires,
+    extras_require={"doc": doc_requires},
     namespace_packages=['sphinxcontrib'],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ The extension defines the directives, "youtube" and "vimeo", for embedding
 YouTube and Vimeo videos, respectively.
 '''
 
-requires = ['Sphinx>=0.6']
+requires = ['Sphinx>=0.6', "requests"]
 doc_requires = ["sphinx-copybutton", "furo"]
 
 setup(

--- a/sphinxcontrib/youtube/__init__.py
+++ b/sphinxcontrib/youtube/__init__.py
@@ -1,7 +1,9 @@
-from  . import youtube, vimeo
-
+from  . import youtube, vimeo, utils
+    
 def setup(app):
     app.add_node(youtube.youtube, **youtube._NODE_VISITORS)
     app.add_directive("youtube", youtube.YouTube)
     app.add_node(vimeo.vimeo, **vimeo._NODE_VISITORS)
     app.add_directive("vimeo", vimeo.Vimeo)
+    app.connect('builder-inited', utils.configure_image_download)
+    app.connect('env-updated', utils.download_images)

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -98,12 +98,16 @@ def depart_video_node(self, node):
 
 
 def visit_video_node_latex(self, node, platform, platform_url):
+    
+    folder = r"\graphicspath{ {./%s/}{./} }" % THUMBNAIL_DIR
+    if folder not in self.elements["preamble"]:
+        self.elements["preamble"] += folder + "\n"
 
-    macro = r"\sphinxcontrib%s" % platform
+    macro = f"\\sphinxcontrib{platform}"
     if macro not in self.elements["preamble"]:
-        self.elements["preamble"] += r"""
-        \newcommand{%s}[3]{\begin{quote}\begin{center}\fbox{\url{#1#2#3}}\end{center}\end{quote}}
-        """ % macro
+        cmd = r"\newcommand{%s}[3]{\begin{quote}\begin{center}\fbox{\url{#1#2#3}}\end{center}\end{quote}}" % macro
+        self.elements["preamble"] += cmd + "\n"
+    
     self.body.append('%s{%s}{%s}{%s}\n' % (macro, platform_url, node['id'], node['url_parameters']))
 
 

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -4,8 +4,18 @@
 import re
 from docutils import nodes
 from docutils.parsers.rst import directives, Directive
+from sphinx.util import logging
+from sphinx.util.console import brown
+from sphinx.util import status_iterator
+import os
+import requests
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 CONTROL_HEIGHT = 30
+
+THUMBNAIL_DIR = "_video_thumbnail"
 
 
 def get_size(d, key):
@@ -88,6 +98,7 @@ def depart_video_node(self, node):
 
 
 def visit_video_node_latex(self, node, platform, platform_url):
+
     macro = r"\sphinxcontrib%s" % platform
     if macro not in self.elements["preamble"]:
         self.elements["preamble"] += r"""
@@ -98,6 +109,7 @@ def visit_video_node_latex(self, node, platform, platform_url):
 
 class Video(Directive):
     _node = None # Subclasses should replace with node class.
+    _thumbnail_url = "{}" # url to retreive thumbnail images
     has_content = True
     required_arguments = 1
     optional_arguments = 0
@@ -111,6 +123,13 @@ class Video(Directive):
     }
 
     def run(self):
+        
+        env = self.state.document.settings.env 
+        video_id = self.arguments[0]
+        url = self._thumbnail_url.format(video_id)
+        env.remote_images[url] = Path(THUMBNAIL_DIR, f"{video_id}.jpg")
+        env.images.add_file('', env.remote_images[url])
+    
         if "aspect" in self.options:
             aspect = self.options.get("aspect")
             m = re.match(r"(\d+):(\d+)", aspect)
@@ -119,15 +138,15 @@ class Video(Directive):
             aspect = tuple(int(x) for x in m.groups())
         else:
             aspect = None
+            
+        alignment = ["left", "center", "right"]
         if "align" in self.options:
             align = self.options.get("align")
-            if align not in ["left", "center", "right"]:
-                raise ValueError(
-                    "invalid alignment. "
-                    "choices are [\"left\", \"center\", \"right\"]"
-                )
+            if align not in alignment:
+                raise ValueError(f"invalid alignment choices are: {alignment}")
         else:
             align = None
+            
         width = get_size(self.options, "width")
         height = get_size(self.options, "height")
         url_parameters = self.options.get("url_parameters", "")
@@ -140,3 +159,28 @@ def unsupported_visit_video(self, node, platform):
         '{}: unsupported output format (node skipped)'.format(platform)
     )
     raise nodes.SkipNode
+
+def download_images(app, env):
+
+    iterator = app.builder.status_iterator if hasattr(app.builder, 'status_iterator') else status_iterator
+    msg = 'Downloading remote images...'
+    for src in iterator(env.remote_images, msg, brown, len(env.remote_images)):
+        
+        dst = Path(app.outdir) / env.remote_images[src]
+        if not dst.is_file():
+            logger.info(f'{src} -> {dst} (downloading)')
+            with open(dst, 'wb') as f:
+                try:
+                    f.write(requests.get(src).content)
+                except requests.ConnectionError:
+                    logger.info(f'Cannot download "{src}"')
+        else:
+            logger.info(f'{src} -> {dst} (already in cache)')
+            
+def configure_image_download(app):
+    
+    app.env.remote_images = {}
+
+    output_dir = Path(app.outdir) / THUMBNAIL_DIR
+    output_dir.mkdir(exist_ok=True)
+    app.config.html_static_path.append(str(output_dir))

--- a/sphinxcontrib/youtube/vimeo.py
+++ b/sphinxcontrib/youtube/vimeo.py
@@ -9,6 +9,7 @@ class vimeo(utils.video):
 
 class Vimeo(utils.Video):
     _node = vimeo
+    _thumbnail_url = "https://vumbnail.com/{}.jpg"
 
 
 def visit_vimeo_node(self, node):

--- a/sphinxcontrib/youtube/youtube.py
+++ b/sphinxcontrib/youtube/youtube.py
@@ -9,6 +9,7 @@ class youtube(utils.video):
 
 class YouTube(utils.Video):
     _node = youtube
+    _thumbnail_url = "https://i3.ytimg.com/vi/{}/maxresdefault.jpg"
 
 
 def visit_youtube_node(self, node):


### PR DESCRIPTION
Fix #24 and Fix #11. Using the ID of the video, the thumbnails are downloaded to the output directory. They are stored in a _video_thumbnail directory using their id as name meaning that this video:

```rst
..  youtube:: dQw4w9WgXcQ
```

will download the following image in a `_video_thumbnail/dQw4w9WgXcQ.jpeg` file.

![rick roll](https://i3.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg)

Files are downloaded only once to reduce the size of the output file. Some output are send to the user. 

```rst
Mise à jour de l'environnement : 0 ajouté(s), 1 modifié(s), 0 supprimé(s)
Lecture des sources... [100%] index
https://i3.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg -> /Users/pierrickrambaud/Documents/travail/FAO/app_buffer/youtube/docs/build/html/_video_thumbnail/dQw4w9WgXcQ.jpg (already in cache)
```

The Latex default output remains the same but i updated the readme with an example of custom command using these images. 

Also note that for testing purposes I created a single page documentation output, everything is up and ready to be linked to a RDT page if you want. It needs to install the "doc" requirements as set-up in the readthedocs.yaml file.

I added the requests lib to the requirements. Everything could also be handled with `distutil` but I prefers `requests`... let me know If you want me to change it. 


Happy to read your comments !


