### PR TITLE
Add :privacy_mode: option for youtube

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ To start the video at a specific time the parameter "url_parameters" may be used
         :url_parameters: "#t=3m13s"
 
 For YouTube "privacy mode", use the directive option
-``:privacy_mode:`` (and for vimeo, ``:url_options: ?dnt=1``)::
+``:privacy_mode:`` (and for vimeo, ``:url_parameters: ?dnt=1``)::
 
     ..  youtube:: oHg5SJYRHA0
         :privacy_mode:

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,12 @@ To start the video at a specific time the parameter "url_parameters" may be used
     .. vimeo:: 73214621
         :url_parameters: "#t=3m13s"
 
+For YouTube "privacy mode", use the directive option
+``:privacy_mode:`` (and for vimeo, ``:url_options: ?dnt=1``)::
+
+    ..  youtube:: oHg5SJYRHA0
+        :privacy_mode:
+
 In LaTeX output, the following code will be emitted for YouTube::
 
     \sphinxcontribyoutube{https://youtu.be/}{oHg5SJYRHA0}{?start=300}

--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -25,11 +25,13 @@ class video(nodes.General, nodes.Element):
     pass
 
 
-def visit_video_node(self, node, platform_url):
+def visit_video_node(self, node, platform_url, platform_url_privacy=None):
     aspect = node["aspect"]
     width = node["width"]
     height = node["height"]
     url_parameters = node["url_parameters"]
+    if node.get('privacy_mode') and platform_url_privacy:
+        platform_url = platform_url_privacy
 
     if aspect is None:
         aspect = 16, 9
@@ -108,6 +110,7 @@ class Video(Directive):
         "aspect": directives.unchanged,
         "align": directives.unchanged,
         "url_parameters": directives.unchanged,
+        "privacy_mode": directives.unchanged,
     }
 
     def run(self):
@@ -132,7 +135,8 @@ class Video(Directive):
         height = get_size(self.options, "height")
         url_parameters = self.options.get("url_parameters", "")
         return [self._node(id=self.arguments[0], aspect=aspect, width=width,
-                height=height, align=align, url_parameters=url_parameters)]
+                height=height, align=align, url_parameters=url_parameters,
+                privacy_mode=self.options.get('privacy_mode'))]
 
 
 def unsupported_visit_video(self, node, platform):

--- a/sphinxcontrib/youtube/youtube.py
+++ b/sphinxcontrib/youtube/youtube.py
@@ -12,7 +12,10 @@ class YouTube(utils.Video):
 
 
 def visit_youtube_node(self, node):
-    return utils.visit_video_node(self, node, platform_url="https://www.youtube.com/embed/")
+    return utils.visit_video_node(self, node,
+                                  platform_url="https://www.youtube.com/embed/",
+                                  platform_url_privacy="https://www.youtube-nocookie.com/embed/"
+                                  )
 
 
 def visit_youtube_node_latex(self, node):


### PR DESCRIPTION
- Add a :privacy_mode: option for YouTube

  - Actually added to the the generic Video node, but platforms may
    choose to implement it or not.

  - The option changes the platform_url to a seprately specified
    platform_url_privacy (implemented for YouTube only) so far.

  - No changes in writers other than HTML.

- Closes: #22

- Review

  - Consider if the way the option is passed through the directive,
    node, and node visitors make sense.  This seemed to be the
    fastest, least-intrusive way to do this, but that doesn't mean it
    is best.

  - I considered using `privacy-mode` instead of `privacy_mode` for
    the option name (and still prefer that).  But `url_parameters`
    uses understore so ...

  - Vimeo uses a ?dnt=1 paramater, which is hard to generalize to
    this.  If the platform_url was a template string which would
    replace `{}` with the URL, this would be easier.
