### PR TITLE
fix: only download thumbnails in latex builds

### DIFF
--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -189,6 +189,10 @@ def merge_download_images(app, env, docnames, other):
 
 def download_images(app, env):
 
+    # images should only be downloaded if the builder is Latex related
+    if "latex" not in app.builder.name:
+        return
+
     iterator = (
         app.builder.status_iterator
         if hasattr(app.builder, "status_iterator")


### PR DESCRIPTION
this PR does prevent the download of the images if the builder is not a a latex related one. 
In your html output, the `_video_thumbnails` folder will still be created but it will remains empty. 

I tested it on the repository documentation and it seems to work as expected.

Fix #42 