### PR TITLE
fix: use correct url when using privacy mode

### DIFF
--- a/sphinxcontrib/youtube/youtube.py
+++ b/sphinxcontrib/youtube/youtube.py
@@ -22,7 +22,7 @@ def visit_youtube_node(self, node):
     """Custom html visit node."""
     privacy = "https://www.youtube-nocookie.com/embed/"
     embed = "https://www.youtube.com/embed/"
-    node["platform_url"] = privacy if node["privacy_mode"] else embed
+    node["platform_url"] = embed if node["privacy_mode"] is None else privacy
     return utils.visit_video_node_html(self, node)
 
 

--- a/sphinxcontrib/youtube/youtube.py
+++ b/sphinxcontrib/youtube/youtube.py
@@ -16,12 +16,13 @@ class YouTube(utils.Video):
     _thumbnail_url = "https://i3.ytimg.com/vi/{}/maxresdefault.jpg"
     _platform = "youtube"
     _platform_url = "https://youtu.be/"
-    _platform_url_privacy = "https://www.youtube-nocookie.com/embed/"
 
 
 def visit_youtube_node(self, node):
     """Custom html visit node."""
-    node["platform_url"] = "https://www.youtube.com/embed/"
+    privacy = "https://www.youtube-nocookie.com/embed/"
+    embed = "https://www.youtube.com/embed/"
+    node["platform_url"] = privacy if node["privacy_mode"] else embed
     return utils.visit_video_node_html(self, node)
 
 


### PR DESCRIPTION
Fix #57 

I simply edit the url used when privacy_mode is activated. 
@phw, could you test it against your documentation and let me know if it fixes the issue ?