### PR TITLE
fix 'status_iterator' duplicate package

### DIFF
--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -6,9 +6,8 @@ from pathlib import Path
 import requests
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from sphinx.util import logging
+from sphinx.util import logging, status_iterator
 from sphinx.util.console import brown
-from sphinx.util.display import status_iterator
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
One day, I failed sphinx build which version is 4.4.0 with following error.
```
Extension error:
Could not import extension sphinxcontrib.youtube (exception: No module named 'sphinx.util.display')
```
It seems 'status iterator' class had been duplicated in 2 packages and was deleted it 'sphinx.util.display'.

[https://www.sphinx-doc.org/en/master/extdev/deprecated.html](https://www.sphinx-doc.org/en/master/extdev/deprecated.html)