### PR TITLE
Use string for status indicator during LaTeX image download

### DIFF
--- a/sphinxcontrib/youtube/utils.py
+++ b/sphinxcontrib/youtube/utils.py
@@ -7,7 +7,6 @@ import requests
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from sphinx.util import logging
-from sphinx.util.console import brown
 from sphinx.util.display import status_iterator
 
 logger = logging.getLogger(__name__)
@@ -261,7 +260,7 @@ def download_images(app, env):
     )
     msg = "Downloading remote images..."
     nb_images = len(env.video_remote_images)
-    for src in iterator(env.video_remote_images, msg, brown, nb_images):
+    for src in iterator(env.video_remote_images, msg, "brown", nb_images):
 
         dst = Path(app.outdir) / env.video_remote_images[src]
         if not dst.is_file():


### PR DESCRIPTION
Using the `brown` function from Sphinx errored as it was a function not a string.

For example it would raise the following:
```
Downloading remote images...[ 50%] --- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.13/logging/__init__.py", line 1151, in emit
    msg = self.format(record)
  File "/usr/lib/python3.13/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ~~~~~~~~~~^^^^^^^^
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/util/logging.py", line 574, in format
    return colourise(colour_name, message)
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/_cli/util/colour.py", line 58, in colourise
    if colour_name.startswith('_') or colour_name in {
       ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'function' object has no attribute 'startswith'
Call stack:
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/__main__.py", line 9, in <module>
    raise SystemExit(main(sys.argv[1:]))
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/cmd/build.py", line 493, in main
    return build_main(argv)
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/cmd/build.py", line 432, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/application.py", line 442, in build
    self.builder.build_update()
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/builders/__init__.py", line 378, in build_update
    self.build(['__all__'], summary=to_build, method='update')
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/builders/__init__.py", line 409, in build
    updated_docnames = set(self.read())
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/builders/__init__.py", line 570, in read
    for retval in self.events.emit('env-updated', self.env):
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/events.py", line 441, in emit
    results.append(listener.handler(self._app, *args))
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinxcontrib/youtube/utils.py", line 264, in download_images
    for src in iterator(env.video_remote_images, msg, brown, nb_images):
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/util/display.py", line 49, in status_iterator
    logger.info(stringify_func(item), nonl=True, color=color)
  File "/usr/lib/python3.13/logging/__init__.py", line 1908, in info
    self.log(INFO, msg, *args, **kwargs)
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/util/logging.py", line 138, in log
    super().log(level, msg, *args, **kwargs)
  File "/usr/lib/python3.13/logging/__init__.py", line 1946, in log
    self.logger.log(level, msg, *args, **kwargs)
  File "/usr/lib/python3.13/logging/__init__.py", line 1590, in log
    self._log(level, msg, args, **kwargs)
  File "/usr/lib/python3.13/logging/__init__.py", line 1665, in _log
    self.handle(record)
  File "/usr/lib/python3.13/logging/__init__.py", line 1681, in handle
    self.callHandlers(record)
  File "/usr/lib/python3.13/logging/__init__.py", line 1737, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python3.13/logging/__init__.py", line 1027, in handle
    self.emit(record)
  File "/home/connor/Code/firedrake-dev/release-250722/venv-release-250722/lib/python3.13/site-packages/s
phinx/util/logging.py", line 219, in emit
    super().emit(record)
Message: 'https://i3.ytimg.com/vi/xhxvM1N8mDQ?modestbranding=1;controls=0;rel=0/maxresdefault.jpg'
Arguments: ()
https://i3.ytimg.com/vi/xhxvM1N8mDQ?modestbranding=1;controls=0;rel=0/maxresdefault.jpg -> /home/connor/C
ode/firedrake-dev/release-250722/firedrake/docs/build/latex/_video_thumbnail/xhxvM1N8mDQ?modestbranding=1
;controls=0;rel=0.jpg (downloading)


```